### PR TITLE
cforest can handle missings in features via surrogate splits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,9 @@ mlr_2.4:
 - option fix.factors in makeLearner was renamed to fix.factors.prediction for clarity
 - getTaskData now has recodeY = "drop.levels" which drops empty factor levels
 - new measures
--- brier
+- brier
+- add missings properties to all ctree and cforest methods:
+  regr/classif for ctree, regr/classif/surv for cforest, and regr/classif for blackboost
 
 mlr_2.3:
 - resample now returns an object of class ResampleResult (downward compatible)

--- a/R/RLearner_classif_blackboost.R
+++ b/R/RLearner_classif_blackboost.R
@@ -24,7 +24,7 @@ makeRLearner.classif.blackboost = function() {
     properties = c("twoclass", "missings", "numerics", "factors", "prob", "weights"),
     name = "Gradient Boosting With Regression Trees",
     short.name = "blackbst",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_classif_cforest.R
+++ b/R/RLearner_classif_cforest.R
@@ -29,7 +29,7 @@ makeRLearner.classif.cforest = function() {
     par.vals = list(),
     name = "Random forest based on conditional inference trees",
     short.name = "cforest",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_classif_cforest.R
+++ b/R/RLearner_classif_cforest.R
@@ -25,7 +25,7 @@ makeRLearner.classif.cforest = function() {
       makeIntegerLearnerParam(id = "maxdepth", lower = 0L, default = 0L),
       makeLogicalLearnerParam(id = "savesplitstats", default = FALSE)
     ),
-    properties = c("twoclass", "multiclass", "prob", "factors", "numerics", "ordered", "weights"),
+    properties = c("twoclass", "multiclass", "prob", "factors", "numerics", "ordered", "weights", "missings"),
     par.vals = list(),
     name = "Random forest based on conditional inference trees",
     short.name = "cforest",

--- a/R/RLearner_classif_ctree.R
+++ b/R/RLearner_classif_ctree.R
@@ -19,7 +19,7 @@ makeRLearner.classif.ctree = function() {
     properties = c("twoclass", "multiclass", "missings", "numerics", "factors", "ordered", "prob", "weights"),
     name = "Conditional Inference Trees",
     short.name = "ctree",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_regr_blackBoost.R
+++ b/R/RLearner_regr_blackBoost.R
@@ -20,10 +20,10 @@ makeRLearner.regr.blackboost = function() {
       makeLogicalLearnerParam(id = "savesplitstats", default = TRUE),
       makeIntegerLearnerParam(id = "maxdepth", default = 0L, lower = 0L)
     ),
-    properties = c("numerics", "factors", "weights"),
+    properties = c("numerics", "factors", "weights", "missings"),
     name = "Gradient Boosting with Regression Trees",
     short.name = "blackbst",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_regr_cforest.R
+++ b/R/RLearner_regr_cforest.R
@@ -25,7 +25,7 @@ makeRLearner.regr.cforest = function() {
       makeIntegerLearnerParam(id = "maxdepth", lower = 0L, default = 0L),
       makeLogicalLearnerParam(id = "savesplitstats", default = FALSE)
     ),
-    properties = c("numerics", "factors", "ordered", "weights"),
+    properties = c("numerics", "factors", "ordered", "weights", "missings"),
     par.vals = list(),
     name = "Random Forest Based on Conditional Inference Trees",
     short.name = "cforest",

--- a/R/RLearner_regr_cforest.R
+++ b/R/RLearner_regr_cforest.R
@@ -29,7 +29,7 @@ makeRLearner.regr.cforest = function() {
     par.vals = list(),
     name = "Random Forest Based on Conditional Inference Trees",
     short.name = "cforest",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_regr_ctree.R
+++ b/R/RLearner_regr_ctree.R
@@ -19,7 +19,7 @@ makeRLearner.regr.ctree = function() {
     properties = c("missings", "numerics", "factors", "ordered", "weights"),
     name = "Conditional Inference Trees",
     short.name = "ctree",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_surv_cforest.R
+++ b/R/RLearner_surv_cforest.R
@@ -29,7 +29,7 @@ makeRLearner.surv.cforest = function() {
     par.vals = list(),
     name = "Random Forest based on Conditional Inference Trees",
     short.name = "crf",
-    note = ""
+    note = "see ?ctree_control for possible breakage for nominal features with missingness"
   )
 }
 

--- a/R/RLearner_surv_cforest.R
+++ b/R/RLearner_surv_cforest.R
@@ -25,7 +25,7 @@ makeRLearner.surv.cforest = function() {
       makeIntegerLearnerParam(id = "maxdepth", lower = 0L, default = 0L),
       makeLogicalLearnerParam(id = "savesplitstats", default = FALSE)
     ),
-    properties = c("factors", "numerics", "ordered", "weights", "rcens"),
+    properties = c("factors", "numerics", "ordered", "weights", "rcens", "missings"),
     par.vals = list(),
     name = "Random Forest based on Conditional Inference Trees",
     short.name = "crf",


### PR DESCRIPTION
the documentation for `ctree_control` says that it is restricted to ordered predictors but there doesn't appear to be any error checking or problems in doing so. I have only given a cursory look through `SurrogateSplits.c`, however, so I am not sure what is up there yet. If nominal missings are a problem should this be checked in `mlr`?

The below examples are from the `cforest` example section.

```{r}
## classification, where i insert missingness into an unordered factor
data("mammoexp", package = "TH.data")
mammoexp$HIST[sample(1:nrow(mammoexp), 25)] <- NA
mamofit <- cforest(ME ~ ., mammoexp)

## survival
data("GBSG2", package = "TH.data")
GBSG2$tsize[sample(1:nrow(GBSG2), 25)] <- NA
bst <- cforest(Surv(time, cens) ~ ., data = GBSG2, 
               control = cforest_unbiased(ntree = 50))

data(iris)
iris$Petal.Width[sample(1:nrow(iris), 10)] <- NA
iris.cf <- cforest(Species ~ ., data = iris, 
                          control = cforest_unbiased(mtry = 2))


```