### PR TITLE
dplyr data_frame breaks performance

### DIFF
--- a/R/Prediction.R
+++ b/R/Prediction.R
@@ -33,6 +33,8 @@ makePrediction = function(task.desc, row.names, id, truth, predict.type, predict
 makePrediction.TaskDescRegr = function(task.desc, row.names, id, truth, predict.type, predict.threshold = NULL, y, time) {
   data = namedList(c("id", "truth", "response", "se"))
   data$id = id
+  if (!is.null(names(truth)))
+      names(truth) = NULL
   data$truth = truth
   if (predict.type == "response") {
     data$response = y


### PR DESCRIPTION
Code to reproduce the bug is below. I only tested it with `cforest` so I could be wrong that `dplyr` is the only cause. I think a better way to handle this would be to strip the attributes when making the task, as this could be introducing other bugs. Is `assertDataFrame` supposed to check for this sort of thing? I looked for it but couldn't find it.

```{r}
library(mlr)
library(dplyr)

data(swiss)

task <- makeRegrTask("swiss", swiss, "Fertility")
learner <- makeLearner("regr.cforest", "swiss", ntree = 1000)
fit <- train(learner, task)
pred <- predict(fit, task)
## colnames(pred$data)[2] <- "truth"
performance(pred, measures = list(mse, mae))

task <- makeRegrTask("swiss", as_data_frame(swiss), "Fertility")
learner <- makeLearner("regr.cforest", "swiss", ntree = 1000)
fit <- train(learner, task)
pred <- predict(fit, task)
performance(pred, mse)
## Error in FUN(X[[1L]], ...) : 
##   You need to have a 'truth' column in your pred object for measure mse!
colnames(pred$data)[2] <- "truth"
performance(pred, mse)
##      mse 
## 87.87757 
```