### PR TITLE
improvements to plotROCRCurves from #247

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,12 @@ mlr_2.4:
 - getTaskData now has recodeY = "drop.levels" which drops empty factor levels
 - new measures
 -- brier
+- new defaults for plotROCRCurves
+-- avg and add.diag set depending on inputs
+-- fill set to NULL by default
+-- bty (box around legend) set to "n" by default
+- ylim bug for plotROCRCurves fixed
+- can now pass arguments to ROCR::plot via plot.args
 
 mlr_2.3:
 - resample now returns an object of class ResampleResult (downward compatible)

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -28,7 +28,7 @@
 #'   Default is \code{TRUE} if more than one ROC curve is drawn.
 #' @param add.diag [\code{logical(1)}]\cr
 #'   Add main diagonal to plot via \code{\link{abline}}?
-#'   Default is \code{TRUE}.
+#'   Default is \code{FALSE} unless \code{meas1 = "tpr"} and \code{meas2 = "fpr"}.
 #' @param perf.args [named \code{list}]\cr
 #'   Further arguments passed to ROCR's \code{\link[ROCR]{performance}}.
 #'   Usually not needed and \code{meas1} and \code{meas2} are set internally.
@@ -54,7 +54,7 @@
 #' }
 plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
   # lets not check the value-names from ROCR here. they might be changed behind our back later...
   assertString(meas1)
@@ -67,7 +67,8 @@ plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
     assertCharacter(ltys, any.missing = FALSE)
   if (!is.null(add.legend))
     assertFlag(add.legend)
-  assertFlag(add.diag)
+  if (!is.null(add.diag))
+    assertFlag(add.diag)
   assertList(perf.args, names = "unique")
   assertList(plot.args, names = "unique")
   assertList(legend.args, names = "unique")
@@ -77,7 +78,7 @@ plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
 #' @export
 plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE, perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = FALSE, perf.args = list(), legend.args = list(), task.id = NULL) {
 
   l = namedList(names = "prediction", init = obj)
   plotROCRCurves.list(l, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
@@ -86,7 +87,7 @@ plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "t
 #' @export
 plotROCRCurves.ResampleResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE,  perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL,  perf.args = list(), legend.args = list(), task.id = NULL) {
 
   l = namedList(names = obj$learner.id, init = obj)
   plotROCRCurves.list(l, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
@@ -95,7 +96,7 @@ plotROCRCurves.ResampleResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg 
 #' @export
 plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
   assertList(obj, c("Prediction", "ResampleResult"), min.len = 1L)
   k = length(obj)
@@ -136,6 +137,14 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
     cargs = list(x = "bottomright", legend = ns, col = cols, fill = cols, lty = ltys, bty = "n")
     cargs = insert(cargs, legend.args)
     do.call(legend, cargs)
+  }
+  
+  if (is.null(add.diag)) {
+    if (meas1 == "tpr" & meas2 == "fpr") {
+      add.diag = TRUE
+    }
+  } else {
+    add.diag = FALSE
   }
   if (add.diag)
     abline(b = 1, a = 0)

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -33,6 +33,9 @@
 #'   Further arguments passed to ROCR's \code{\link[ROCR]{performance}}.
 #'   Usually not needed and \code{meas1} and \code{meas2} are set internally.
 #'   Default is an empty list.
+#' @param plot.args [named \code{list}]\cr
+#'   Further arguments passed to ROCR's code{\link{ROCR}{plot}}.
+#'   Default is an empty list.
 #' @param legend.args [named \code{list}]\cr
 #'   Further arguments passed to \code{\link{legend}}.
 #'   Default is to display the names or learner ids of \code{obj},
@@ -50,7 +53,7 @@
 #' lrn1 = makeLearner("classif.logreg", predict.type = "prob")
 #' lrn2 = makeLearner("classif.rpart", predict.type = "prob")
 #' b = benchmark(list(lrn1, lrn2), pid.task)
-#' z = plotROCRCurves(b, legend.args = list(fill = NULL))
+#' z = plotROCRCurves(b)
 #' }
 plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
@@ -134,7 +137,7 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
     add.legend = (k > 1L)
   if (add.legend) {
     ns = names(obj)
-    cargs = list(x = "bottomright", legend = ns, col = cols, fill = cols, lty = ltys, bty = "n")
+    cargs = list(x = "bottomright", legend = ns, col = cols, fill = NULL, lty = ltys, bty = "n")
     cargs = insert(cargs, legend.args)
     do.call(legend, cargs)
   }

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -81,7 +81,7 @@ plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
 #' @export
 plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = FALSE, perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL, perf.args = list(), legend.args = list(), task.id = NULL) {
 
   l = namedList(names = "prediction", init = obj)
   plotROCRCurves.list(l, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -18,6 +18,7 @@
 #'   How to average results from resampling.
 #'   Default is \dQuote{none} when \code{obj} is a (list of) prediction objects and
 #'   \dQuote{threshold} when \code{obj} is a (list of) \code{ResamplePrediction} or \code{BenchmarkResult}.
+#'   For more details see \code{\link[ROCR]{plot-methods}}.
 #' @param cols [\code{character}]\cr
 #'   Colors of curves. Single strings are replicated to desired length.
 #'   Default is to use \code{\link{rainbow}}.

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -122,8 +122,9 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
     cargs$prediction.obj = asROCRPrediction(x)
     do.call(ROCR::performance, cargs)
   })
+  ylim <- range(sapply(rocr.perfs, function(x) unlist(x@y.values)))
   for (i in 1:k) {
-    pargs <- list(x = rocr.perfs[[i]], avg = avg, add = (i > 1L), col = cols[i], lty = ltys[i])
+    pargs <- list(x = rocr.perfs[[i]], avg = avg, add = (i > 1L), col = cols[i], lty = ltys[i], ylim = ylim)
     pargs <- insert(pargs, plot.args)
     do.call(ROCR::plot, pargs)
   }

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -126,7 +126,6 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
     pargs <- list(x = rocr.perfs[[i]], avg = avg, add = (i > 1L), col = cols[i], lty = ltys[i])
     pargs <- insert(pargs, plot.args)
     do.call(ROCR::plot, pargs)
-    ## ROCR::plot(rocr.perfs[[i]], avg = avg, add = (i > 1L), col = cols[i], lty = ltys[i])
   }
 
   if (is.null(add.legend))

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -133,7 +133,7 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
     add.legend = (k > 1L)
   if (add.legend) {
     ns = names(obj)
-    cargs = list(x = "bottomright", legend = ns, col = cols, fill = cols, lty = ltys)
+    cargs = list(x = "bottomright", legend = ns, col = cols, fill = cols, lty = ltys, bty = "n")
     cargs = insert(cargs, legend.args)
     do.call(legend, cargs)
   }

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -98,6 +98,19 @@ plotROCRCurves.ResampleResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg 
 }
 
 #' @export
+plotROCRCurves.BenchmarkResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold", cols = NULL, ltys = NULL,
+  add.legend = NULL, add.diag = TRUE, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
+
+  tids = getBMRTaskIds(obj)
+  if (is.null(task.id))
+    task.id = tids[1L]
+  else
+    assertChoice(task.id, tids)
+  ps = getBMRPredictions(obj, task.ids = task.id, as.df = FALSE)[[1L]]
+  plotROCRCurves.list(ps, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
+}
+
+#' @export
 plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL,
   add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
@@ -153,17 +166,4 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   if (add.diag)
     abline(b = 1, a = 0)
   invisible(NULL)
-}
-
-#' @export
-plotROCRCurves.BenchmarkResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold", cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
-
-  tids = getBMRTaskIds(obj)
-  if (is.null(task.id))
-    task.id = tids[1L]
-  else
-    assertChoice(task.id, tids)
-  ps = getBMRPredictions(obj, task.ids = task.id, as.df = FALSE)[[1L]]
-  plotROCRCurves.list(ps, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
 }

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -82,7 +82,7 @@ plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
 #' @export
 plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = NULL, perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
   l = namedList(names = "prediction", init = obj)
   plotROCRCurves.list(l, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
@@ -91,7 +91,7 @@ plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "n
 #' @export
 plotROCRCurves.ResampleResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
   cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = NULL,  perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = NULL,  perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
   l = namedList(names = obj$learner.id, init = obj)
   plotROCRCurves.list(l, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
@@ -157,7 +157,7 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
 
 #' @export
 plotROCRCurves.BenchmarkResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold", cols = NULL, ltys = NULL,
-  add.legend = NULL, add.diag = TRUE, perf.args = list(), legend.args = list(), task.id = NULL) {
+  add.legend = NULL, add.diag = TRUE, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
   tids = getBMRTaskIds(obj)
   if (is.null(task.id))
@@ -165,5 +165,5 @@ plotROCRCurves.BenchmarkResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg
   else
     assertChoice(task.id, tids)
   ps = getBMRPredictions(obj, task.ids = task.id, as.df = FALSE)[[1L]]
-  plotROCRCurves.list(ps, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, legend.args)
+  plotROCRCurves.list(ps, meas1, meas2, avg, cols, ltys, add.legend, add.diag, perf.args, plot.args, legend.args)
 }

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -145,10 +145,10 @@ plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "thresho
   if (is.null(add.diag)) {
     if (meas1 == "tpr" & meas2 == "fpr") {
       add.diag = TRUE
-    }
-  } else {
+    } else {
     add.diag = FALSE
-  }
+    }
+  } 
   if (add.diag)
     abline(b = 1, a = 0)
   invisible(NULL)

--- a/R/plotROCRCurves.R
+++ b/R/plotROCRCurves.R
@@ -16,7 +16,8 @@
 #'   Default is \dQuote{fpr}.
 #' @param avg [\code{character(1)}]\cr
 #'   How to average results from resampling.
-#'   Default is \dQuote{threshold}.
+#'   Default is \dQuote{none} when \code{obj} is a (list of) prediction objects and
+#'   \dQuote{threshold} when \code{obj} is a (list of) \code{ResamplePrediction} or \code{BenchmarkResult}.
 #' @param cols [\code{character}]\cr
 #'   Colors of curves. Single strings are replicated to desired length.
 #'   Default is to use \code{\link{rainbow}}.
@@ -55,7 +56,7 @@
 #' b = benchmark(list(lrn1, lrn2), pid.task)
 #' z = plotROCRCurves(b)
 #' }
-plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
+plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL,
   add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 
@@ -79,7 +80,7 @@ plotROCRCurves = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
 }
 
 #' @export
-plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
+plotROCRCurves.Prediction = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL,
   add.legend = NULL, add.diag = NULL, perf.args = list(), legend.args = list(), task.id = NULL) {
 
@@ -97,7 +98,7 @@ plotROCRCurves.ResampleResult = function(obj, meas1 = "tpr", meas2 = "fpr", avg 
 }
 
 #' @export
-plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
+plotROCRCurves.list = function(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL,
   add.legend = NULL, add.diag = NULL, perf.args = list(), plot.args = list(), legend.args = list(), task.id = NULL) {
 

--- a/man/plotROCRCurves.Rd
+++ b/man/plotROCRCurves.Rd
@@ -5,8 +5,9 @@
 \title{Visualize binary classification predictions via ROCR ROC curves.}
 \usage{
 plotROCRCurves(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
-  cols = NULL, ltys = NULL, add.legend = NULL, add.diag = TRUE,
-  perf.args = list(), legend.args = list(), task.id = NULL)
+  cols = NULL, ltys = NULL, add.legend = NULL, add.diag = NULL,
+  perf.args = list(), plot.args = list(), legend.args = list(),
+  task.id = NULL)
 }
 \arguments{
 \item{obj}{[(list of) \code{\link{Prediction}} | (list of) \code{\link{ResampleResult}} | \code{\link{BenchmarkResult}}]\cr
@@ -41,11 +42,15 @@ Default is \code{TRUE} if more than one ROC curve is drawn.}
 
 \item{add.diag}{[\code{logical(1)}]\cr
 Add main diagonal to plot via \code{\link{abline}}?
-Default is \code{TRUE}.}
+Default is \code{FALSE} unless \code{meas1 = "tpr"} and \code{meas2 = "fpr"}.}
 
 \item{perf.args}{[named \code{list}]\cr
 Further arguments passed to ROCR's \code{\link[ROCR]{performance}}.
 Usually not needed and \code{meas1} and \code{meas2} are set internally.
+Default is an empty list.}
+
+\item{plot.args}{[named \code{list}]\cr
+Further arguments passed to ROCR's code{\link{ROCR}{plot}}.
 Default is an empty list.}
 
 \item{legend.args}{[named \code{list}]\cr

--- a/man/plotROCRCurves.Rd
+++ b/man/plotROCRCurves.Rd
@@ -4,7 +4,7 @@
 \alias{plotROCRCurves}
 \title{Visualize binary classification predictions via ROCR ROC curves.}
 \usage{
-plotROCRCurves(obj, meas1 = "tpr", meas2 = "fpr", avg = "threshold",
+plotROCRCurves(obj, meas1 = "tpr", meas2 = "fpr", avg = "none",
   cols = NULL, ltys = NULL, add.legend = NULL, add.diag = NULL,
   perf.args = list(), plot.args = list(), legend.args = list(),
   task.id = NULL)
@@ -26,7 +26,9 @@ Default is \dQuote{fpr}.}
 
 \item{avg}{[\code{character(1)}]\cr
 How to average results from resampling.
-Default is \dQuote{threshold}.}
+Default is \dQuote{none} when \code{obj} is a (list of) prediction objects and
+\dQuote{threshold} when \code{obj} is a (list of) \code{ResamplePrediction} or \code{BenchmarkResult}.
+For more details see \code{\link[ROCR]{plot-methods}}.}
 
 \item{cols}{[\code{character}]\cr
 Colors of curves. Single strings are replicated to desired length.


### PR DESCRIPTION
things that were added

 - a (by default empty) list to the arguments: `plot.args`
 - `ylim` is set by finding the range of the `y.values` slot of elements of the list `rocr.perfs` across all elements
- `add.diag` is now `NULL` by default, and is set to `FALSE` unless `meas1 = "tpr"` and `meas2 = "fpr"`, appropriate assertions were added in the generic method
 - two defaults were added to the legend, `fill = FALSE` and `bty = "n"`. the former removes the box drawn around the colors corresponding to each line and the latter removes the box around the entire legend

i haven't implemented i from #247 as it is not immediately obvious to me what the defaults should be. 

