### PR TITLE
remove unneeded arguments from plot functions

### DIFF
--- a/R/plotFilterValues.R
+++ b/R/plotFilterValues.R
@@ -9,18 +9,19 @@
 #' @param n.show [\code{integer(1)}]\cr
 #'   Number of features (maximal) to show.
 #'   Default is 20.
-#' @param feat.type.cols [\code{character(2)}*]\cr
-#'   Colors for factor and numeric features.
-#'   \code{NULL} means no colors.
-#'   Default is darkgreen and darkblue.
+#' @param feat.type.cols [\code{logical(1)}]\cr
+#'   Color factor and numeric features.
+#'   \code{FALSE} means no colors.
+#'   Default is \code{FALSE}.
 #' @template ret_gg2
 #' @export
 #' @examples
 #' fv = getFilterValues(iris.task, method = "chi.squared")
 #' plotFilterValues(fv)
-plotFilterValues = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols = c("darkgreen", "darkblue")) {
+plotFilterValues = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols = FALSE) {
   assertClass(fvalues, classes = "FilterValues")
   assertChoice(sort, choices = c("dec", "inc", "none"))
+  assertFlag(feat.type.cols)
   n.show = asCount(n.show)
 
   data = fvalues$data
@@ -29,20 +30,17 @@ plotFilterValues = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols 
     data = head(sortByCol(data, "val", asc = (sort == "inc")), n.show)
 
   data$name = factor(data$name, levels = as.character(data$name))
-  if (!is.null(feat.type.cols)) {
-    assertCharacter(feat.type.cols, len = 2L, any.missing = FALSE)
-    mp = aes_string(x = "name", y = "val", fill = "type")
-  } else {
-    mp = aes_string(x = "name", y = "val")
-  }
-  p = ggplot(data = data, mapping = mp)
-  p = p + geom_bar(position = "identity", stat = "identity")
-  if (!is.null(feat.type.cols))
-    p = p + scale_fill_manual(values = feat.type.cols)
-  p = p + ggtitle(sprintf("%s (%i features), filter = %s",
-    fvalues$task.desc$id, sum(fvalues$task.desc$n.feat), fvalues$method))
-  p = p + xlab("") + ylab("")
-  p = p + theme(axis.text.x = element_text(angle = 45, hjust = 1))
+  if (feat.type.cols)
+    mp = ggplot2::aes_string(x = "name", y = "val", fill = "type")
+  else
+    mp = ggplot2::aes_string(x = "name", y = "val")
+  p = ggplot2::ggplot(data = data, mapping = mp)
+  p = p + ggplot2::geom_bar(position = "identity", stat = "identity")
+  p = p + ggplot2::labs(title = sprintf("%s (%i features), filter = %s",
+                                        fvalues$task.desc$id,
+                                        sum(fvalues$task.desc$n.feat), fvalues$method),
+                        x = "", y = "")
+  p = p + ggplot2::theme(axis.text.x = element_text(angle = 45, hjust = 1))
   return(p)
 }
 #' Plot filter values using ggvis.
@@ -56,18 +54,19 @@ plotFilterValues = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols 
 #' @param n.show [\code{integer(1)}]\cr
 #'   Number of features (maximal) to show.
 #'   Default is 20.
-#' @param feat.type.cols [\code{character(2)}*]\cr
-#'   Colors for factor and numeric features.
-#'   \code{NULL} means no colors.
-#'   Default is darkgreen and darkblue.
+#' @param feat.type.cols [\code{logical(1)}]\cr
+#'   Color factor and numeric features.
+#'   \code{FALSE} means no colors.
+#'   Default is \code{FALSE}.
 #' @template ret_ggv
 #' @export
 #' @examples
 #' fv = getFilterValues(iris.task, method = "chi.squared")
 #' plotFilterValuesGGVIS(fv)
-plotFilterValuesGGVIS = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols = c("darkgreen", "darkblue")) {
+plotFilterValuesGGVIS = function(fvalues, sort = "dec", n.show = 20L, feat.type.cols = FALSE) {
   assertClass(fvalues, classes = "FilterValues")
   assertChoice(sort, choices = c("dec", "inc", "none"))
+  assertFlag(feat.type.cols)
   n.show = asCount(n.show)
 
   data = fvalues$data
@@ -76,18 +75,15 @@ plotFilterValuesGGVIS = function(fvalues, sort = "dec", n.show = 20L, feat.type.
     data = head(sortByCol(data, "val", asc = (sort == "inc")), n.show)
 
   data$name = factor(data$name, levels = as.character(data$name))
-  if (!is.null(feat.type.cols)) {
-    assertCharacter(feat.type.cols, len = 2L, any.missing = FALSE)
+  if (feat.type.cols)
     p = ggvis::ggvis(data, ggvis::prop("x", as.name("name")),
                      ggvis::prop("y", as.name("val")),
                      ggvis::prop("fill", as.name("type")))
-  } else {
+  else
     p = ggvis::ggvis(data, ggvis::prop("x", as.name("name")),
                      ggvis::prop("y", as.name("val")))
-  }
+
   p = ggvis::layer_bars(p)
-  if (!is.null(feat.type.cols))
-      p = ggvis::scale_nominal(p, "fill", range = feat.type.cols)
 
   add_title <- function(vis, ..., x_lab = "", title = "") {
       vis = ggvis::add_axis(vis, "x", title = x_lab)

--- a/R/plotThreshVsPerf.R
+++ b/R/plotThreshVsPerf.R
@@ -8,19 +8,15 @@
 #' @param gridsize [\code{integer(1)}]\cr
 #'   Grid resolution for x-axis (threshold).
 #'   Default is 100.
-#' @param linesize [\code{numeric(1)}]\cr
-#'   Linesize for ggplot2 \code{\link[ggplot2]{geom_line}} for performance graphs.
-#'   Default is 1.5.
 #' @template ret_gg2
 #' @export
-plotThreshVsPerf = function(pred, measures, mark.th = NA_real_, gridsize = 100L, linesize = 1.5) {
+plotThreshVsPerf = function(pred, measures, mark.th = NA_real_, gridsize = 100L) {
   assertClass(pred, classes = "Prediction")
   td = pred$task.desc
   if (td$type != "classif" || length(td$class.levels) != 2L)
     stopf("Task must be binary classification!")
   measures = checkMeasures(measures, td)
   assertNumber(mark.th, na.ok = TRUE, lower = 0, upper = 1)
-  assertNumber(linesize, lower = 0)
 
   mids = extractSubList(measures, "id")
   # grid for predictions
@@ -34,7 +30,7 @@ plotThreshVsPerf = function(pred, measures, mark.th = NA_real_, gridsize = 100L,
   grid = cbind(grid, perf)
   grid = melt(grid, measure.vars = mids, variable.name = "measure", value.name = "perf")
   p = ggplot(data = grid, mapping = aes_string(x = "threshold", y = "perf", col = "measure"))
-  p = p + geom_line(size = linesize)
+  p = p + geom_line()
   if (!is.na(mark.th))
     p = p + geom_vline(xintercept = mark.th)
   return(p)

--- a/man/plotFilterValues.Rd
+++ b/man/plotFilterValues.Rd
@@ -5,7 +5,7 @@
 \title{Plot filter values using ggplot2.}
 \usage{
 plotFilterValues(fvalues, sort = "dec", n.show = 20L,
-  feat.type.cols = c("darkgreen", "darkblue"))
+  feat.type.cols = FALSE)
 }
 \arguments{
 \item{fvalues}{[\code{\link{FilterValues}}]\cr
@@ -20,10 +20,10 @@ Default is decreasing.}
 Number of features (maximal) to show.
 Default is 20.}
 
-\item{feat.type.cols}{[\code{character(2)}*]\cr
-Colors for factor and numeric features.
-\code{NULL} means no colors.
-Default is darkgreen and darkblue.}
+\item{feat.type.cols}{[\code{logical(1)}]\cr
+Color factor and numeric features.
+\code{FALSE} means no colors.
+Default is \code{FALSE}.}
 }
 \value{
 ggplot2 plot object.

--- a/man/plotFilterValuesGGVIS.Rd
+++ b/man/plotFilterValuesGGVIS.Rd
@@ -5,7 +5,7 @@
 \title{Plot filter values using ggvis.}
 \usage{
 plotFilterValuesGGVIS(fvalues, sort = "dec", n.show = 20L,
-  feat.type.cols = c("darkgreen", "darkblue"))
+  feat.type.cols = FALSE)
 }
 \arguments{
 \item{fvalues}{[\code{\link{FilterValues}}]\cr
@@ -20,10 +20,10 @@ Default is decreasing.}
 Number of features (maximal) to show.
 Default is 20.}
 
-\item{feat.type.cols}{[\code{character(2)}*]\cr
-Colors for factor and numeric features.
-\code{NULL} means no colors.
-Default is darkgreen and darkblue.}
+\item{feat.type.cols}{[\code{logical(1)}]\cr
+Color factor and numeric features.
+\code{FALSE} means no colors.
+Default is \code{FALSE}.}
 }
 \value{
 a ggvis plot object.

--- a/man/plotThreshVsPerf.Rd
+++ b/man/plotThreshVsPerf.Rd
@@ -4,8 +4,7 @@
 \alias{plotThreshVsPerf}
 \title{Plot threshold vs. performance(s) for 2-class classification using ggplot2.}
 \usage{
-plotThreshVsPerf(pred, measures, mark.th = NA_real_, gridsize = 100L,
-  linesize = 1.5)
+plotThreshVsPerf(pred, measures, mark.th = NA_real_, gridsize = 100L)
 }
 \arguments{
 \item{pred}{[\code{\link{Prediction}}]\cr
@@ -21,10 +20,6 @@ Default is \code{NA} which means not to do it.}
 \item{gridsize}{[\code{integer(1)}]\cr
 Grid resolution for x-axis (threshold).
 Default is 100.}
-
-\item{linesize}{[\code{numeric(1)}]\cr
-Linesize for ggplot2 \code{\link[ggplot2]{geom_line}} for performance graphs.
-Default is 1.5.}
 }
 \value{
 ggplot2 plot object.


### PR DESCRIPTION
 - plotThresVsPerf loses linesize.
 - for plotFilterValues and plotFilterValuesGGVIS feat.type.cols is
   changed to a flag for whether to color by feature type (no extra
   color defaults). Users can change the colors by using
   scale_fill_manual in ggplot2 or scale_nominal in ggvis.