### PR TITLE
substitute measure names for ids in plots

### DIFF
--- a/R/generateLearningCurve.R
+++ b/R/generateLearningCurve.R
@@ -123,6 +123,12 @@ plotLearningCurve = function(obj, facet = "measure") {
   assertChoice(facet, mappings)
   color = mappings[mappings != facet]
 
+  for (i in 1:length(obj$measures)) {
+    measure.name = obj$measures[[i]]$name
+    colnames(obj$data)[colnames(obj$data) == obj$measures[[i]]$id] = measure.name
+    obj$measures[[i]] = measure.name
+  }
+
   data = reshape2::melt(obj$data,
                         id.vars = c("learner", "perc"),
                         variable.name = "measure", value.name = "perf")
@@ -169,6 +175,12 @@ plotLearningCurveGGVIS = function(obj, interaction = "measure") {
   mappings = c("measure", "learner")
   assertChoice(interaction, mappings)
   color = mappings[mappings != interaction]
+
+  for (i in 1:length(obj$measures)) {
+    measure.name = obj$measures[[i]]$name
+    colnames(obj$data)[colnames(obj$data) == obj$measures[[i]]$id] = measure.name
+    obj$measures[[i]] = measure.name
+  }
 
   data = reshape2::melt(obj$data, id.vars = c("learner", "perc"), variable.name = "measure", value.name = "perf")
   nmeas = length(unique(data$measure))

--- a/R/generateThreshVsPerf.R
+++ b/R/generateThreshVsPerf.R
@@ -95,6 +95,12 @@ plotThreshVsPerf = function(obj, facet = "measure", mark.th = NA_real_) {
   assertChoice(facet, mappings)
   color = mappings[mappings != facet]
 
+  for (i in 1:length(obj$measures)) {
+    measure.name = get(obj$measures[i])$name
+    colnames(obj$data)[colnames(obj$data) == obj$measures[i]] = measure.name
+    obj$measures[i] = measure.name
+  }
+
   data = reshape2::melt(obj$data, measure.vars = obj$measures,
               variable.name = "measure", value.name = "perf",
               id.vars = c("learner", "threshold"))
@@ -150,6 +156,12 @@ plotThreshVsPerfGGVIS = function(obj, interaction = "measure",
   mappings = c("measure", "learner")
   assertChoice(interaction, mappings)
   color = mappings[mappings != interaction]
+
+  for (i in 1:length(obj$measures)) {
+    measure.name = get(obj$measures[i])$name
+    colnames(obj$data)[colnames(obj$data) == obj$measures[i]] = measure.name
+    obj$measures[i] = measure.name
+  }
 
   data = reshape2::melt(obj$data, measure.vars = obj$measures,
                         variable.name = "measure", value.name = "perf",


### PR DESCRIPTION
e.g., instead of "tpr" we'd have "True positive rate". 

I thought about doing this for filters too, but the filter descriptions are often somewhat long. It would be nice to have a more proper name though.

I think this needs to done for the predictions from the survival learners. As @schiffner noted they are all measures of risk but what precisely they are differs amongst some of them and is a pretty important distinction I would think.

