### PR TITLE
solution to labelling problem in #366

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,15 @@ mlr_2.5:
 - there was a nasty bug in measure "mcc". fixed and unit tested. and apologies.
 - removed getTaskFormulaAsString and improved getTaskFormula so the former is
   not needed anymore
+- aggregations now have a 'name' property, which is a long name
+- generateLearningCurveData and generateThreshVsPerfData now append the aggregation id
+  to the output column name if the measure ids are the same
+- plotLearningCurve, plotLearningCurveGGVIS, plotThreshVsPerf, plotThreshVsPerfGGVIS now have an argument
+  'pretty.names' which plots the 'name' element of the measures instead of the 'id'.
+- makeCustomResampledMeasure now has arguments 'measure.id' and 'aggregation.id'
+  instead of only 'id' which corresponded to the measure. Also, 'name' and note (corresponding to the measure)
+  as well as 'aggregation.name' have been added.
+- makeCostMeasure now has arguments 'name' and 'id'.
 
 - new functions
 -- getDefaultMeasure

--- a/R/Aggregation.R
+++ b/R/Aggregation.R
@@ -28,6 +28,8 @@ NULL
 #'
 #' @param id [\code{character(1)}]\cr
 #'   Name of the aggregation method. (Preferably the same name as the generated function)
+#' @param name [\code{character(1)}]\cr
+#'   Long name of the aggregation method.
 #' @param fun [\code{function}]\cr
 #'   A function with following signature: \code{function(task, perf.test, perf.train, measure, group, pred)}
 #'   \itemize{
@@ -42,12 +44,13 @@ NULL
 #' @return \link{Aggregation} object
 #' @examples
 #' # computes the interquartile range on all performance values
-#' test.iqr = makeAggregation(id = "test.iqr",
+#' test.iqr = makeAggregation(id = "test.iqr", name = "Test set interquartile range",
 #'   fun = function (task, perf.test, perf.train, measure, group, pred) IQR(perf.test))
 #' @export
-makeAggregation = function(id, fun) {
+makeAggregation = function(id, name, fun) {
   assertString(id)
-  setClasses(list(id = id, fun = fun), "Aggregation")
+  assertString(name)
+  setClasses(list(id = id, name = name, fun = fun), "Aggregation")
 }
 
 #' @export

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -62,7 +62,7 @@
 #' @param name [\code{character}] \cr
 #'   Name of the measure. Default is \code{id}.
 #' @param note [\code{character}] \cr
-#'   Description and additional notes for the learner. Default is \dQuote{}.
+#'   Description and additional notes for the measure. Default is \dQuote{}.
 #' @template ret_measure
 #' @export
 #' @family performance

--- a/R/Measure_custom_resampled.R
+++ b/R/Measure_custom_resampled.R
@@ -6,34 +6,73 @@
 #' only calculate an aggregated value. If you can define a function that makes sense
 #' for every single training / test set, implement your own \code{\link{Measure}}.
 #'
-#' @param id [\code{character(1)}]\cr
-#'   Name of aggregated measure.
-#' @inheritParams makeMeasure
+#' @param measure.id [\code{character(1)}]\cr
+#'   Short name of measure.
+#' @param measure.name [\code{character(1)}]\cr
+#'   Long name of measure.
+#'   Default is \code{measure.id}.
+#' @param aggregation.id [\code{character(1)}]\cr
+#'   Short name of aggregation.
+#' @param aggregation.name [\code{character(1)}]\cr
+#'   Long name of the aggregation.
+#'   Default is \code{aggregation.id}.
 #' @param fun [\code{function(task, pred, group, pred, extra.args)}]\cr
 #'   Calculates performance value from \code{\link{ResamplePrediction}} object.
 #'   For rare case you can also use the task, the grouping or the extra arguments \code{extra.args}.
 #' @param extra.args [\code{list}]\cr
 #'   List of extra arguments which will always be passed to \code{fun}.
 #'   Default is empty list.
+#' @param minimize [\code{logical(1)}]\cr
+#'   Should the measure be minimized?
+#'   Default is in \code{TRUE}.
+#' @param properties [\code{character}]\cr
+#'   Set of measure properties. Some standard property names include:
+#'   \describe{
+#'     \item{classif}{Is the measure applicable for classification?}
+#'     \item{classif.multi}{Is the measure applicable for multi-class classification?}
+#'     \item{regr}{Is the measure applicable for regression?}
+#'     \item{surv}{Is the measure applicable for survival?}
+#'     \item{costsens}{Is the measure applicable for cost-sensitive learning?}
+#'     \item{req.pred}{Is prediction object required in calculation? Usually the case.}
+#'     \item{req.truth}{Is truth column required in calculation? Usually the case.}
+#'     \item{req.task}{Is task object required in calculation? Usually not the case}
+#'     \item{req.model}{Is model object required in calculation? Usually not the case.}
+#'     \item{req.feats}{Are feature values required in calculation? Usually not the case.}
+#'     \item{req.prob}{Are predicted probabilites required in calculation? Usually not the case, example would be AUC.}
+#'   }
+#'   Default is \code{character(0)}.
+#' @param best [\code{numeric(1)}]\cr
+#'   Best obtainable value for measure.
+#'   Default is -\code{Inf} or \code{Inf}, depending on \code{minimize}.
+#' @param worst [\code{numeric(1)}]\cr
+#'   Worst obtainable value for measure.
+#'   Default is \code{Inf} or -\code{Inf}, depending on \code{minimize}.
+#' @param note [\code{character}] \cr
+#'   Description and additional notes for the measure. Default is \dQuote{}.
 #' @template ret_measure
 #' @family performance
 #' @export
-makeCustomResampledMeasure = function(id, minimize = TRUE, properties = character(0L),
-  fun, extra.args = list(), best = NULL, worst = NULL) {
-
-  assertString(id)
+makeCustomResampledMeasure = function(measure.id, aggregation.id, minimize = TRUE, properties = character(0L),
+                                      fun, extra.args = list(), best = NULL, worst = NULL,
+                                      measure.name = measure.id, aggregation.name = aggregation.id,
+                                      note = "") {
+  assertString(measure.id)
+  assertString(aggregation.id)
   assertFlag(minimize)
   assertCharacter(properties, any.missing = FALSE)
   assertFunction(fun)
   assertList(extra.args)
+  assertString(measure.name)
+  assertString(aggregation.name)
+  assertString(note)
 
   force(fun)
   fun1 = function(task, model, pred, feats, extra.args) NA_real_
   # args are checked here
-  custom = makeMeasure(id = "custom", minimize, properties, fun1, extra.args,
-   best = best, worst = worst)
+  custom = makeMeasure(id = measure.id, minimize, properties, fun1, extra.args,
+   best = best, worst = worst, name = measure.name, note = note)
   fun2 = function(task, perf.test, perf.train, measure, group, pred)
     fun(task, group, pred, extra.args)
-  aggr = makeAggregation(id = id, fun = fun2)
+  aggr = makeAggregation(id = aggregation.id, name = aggregation.name, fun = fun2)
   setAggregation(custom, aggr)
 }

--- a/R/Measure_make_cost.R
+++ b/R/Measure_make_cost.R
@@ -21,12 +21,15 @@
 #' @template ret_measure
 #' @export
 #' @family performance
-makeCostMeasure = function(id = "costs", minimize = TRUE, costs, task, combine = mean, best = NULL, worst = NULL) {
+makeCostMeasure = function(id = "costs", minimize = TRUE, costs, task, combine = mean, best = NULL, worst = NULL,
+                           name = id, note = "") {
   assertString(id)
   assertFlag(minimize)
   assertMatrix(costs)
   assertClass(task, classes = "ClassifTask")
   assertFunction(combine)
+  assertString(name)
+  assertString(note)
 
   #check costs
   td = getTaskDescription(task)
@@ -54,6 +57,8 @@ makeCostMeasure = function(id = "costs", minimize = TRUE, costs, task, combine =
       }
       y = mapply(cc, as.character(pred$data$truth), as.character(r))
       combine(y)
-    }
+    },
+    name = name,
+    note = note
   )
 }

--- a/R/aggregations.R
+++ b/R/aggregations.R
@@ -35,6 +35,7 @@ NULL
 #' @rdname aggregations
 test.mean = makeAggregation(
   id = "test.mean",
+  name = "Test mean",
   fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.test)
 )
 
@@ -42,6 +43,7 @@ test.mean = makeAggregation(
 #' @rdname aggregations
 test.sd = makeAggregation(
   id = "test.sd",
+  name = "Test sd",
   fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.test)
 )
 
@@ -49,6 +51,7 @@ test.sd = makeAggregation(
 #' @rdname aggregations
 test.median = makeAggregation(
   id = "test.median",
+  name = "Test median",
   fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.test)
 )
 
@@ -56,6 +59,7 @@ test.median = makeAggregation(
 #' @rdname aggregations
 test.min = makeAggregation(
   id = "test.min",
+  name = "Test minimum",
   fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.test)
 )
 
@@ -63,6 +67,7 @@ test.min = makeAggregation(
 #' @rdname aggregations
 test.max = makeAggregation(
   id = "test.max",
+  name = "Test maximum",
   fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.test)
 )
 
@@ -70,6 +75,7 @@ test.max = makeAggregation(
 #' @rdname aggregations
 test.sum = makeAggregation(
   id = "test.sum",
+  name = "Test sum",
   fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.test)
 )
 
@@ -77,6 +83,7 @@ test.sum = makeAggregation(
 #' @rdname aggregations
 test.range = makeAggregation(
   id = "test.range",
+  name = "Test range",
   fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.test))
 )
 
@@ -84,6 +91,7 @@ test.range = makeAggregation(
 #' @rdname aggregations
 test.sqrt.of.mean = makeAggregation(
   id = "test.sqrt.of.mean",
+  name = "Test RMSE",
   fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.test))
 )
 
@@ -91,6 +99,7 @@ test.sqrt.of.mean = makeAggregation(
 #' @rdname aggregations
 train.mean = makeAggregation(
   id = "train.mean",
+  name = "Training mean",
   fun = function(task, perf.test, perf.train, measure, group, pred) mean(perf.train)
 )
 
@@ -98,6 +107,7 @@ train.mean = makeAggregation(
 #' @rdname aggregations
 train.sd = makeAggregation(
   id = "train.sd",
+  name = "Training sd",
   fun = function(task, perf.test, perf.train, measure, group, pred) sd(perf.train)
 )
 
@@ -105,6 +115,7 @@ train.sd = makeAggregation(
 #' @rdname aggregations
 train.median = makeAggregation(
   id = "train.median",
+  name = "Training median",
   fun = function(task, perf.test, perf.train, measure, group, pred) median(perf.train)
 )
 
@@ -112,6 +123,7 @@ train.median = makeAggregation(
 #' @rdname aggregations
 train.min = makeAggregation(
   id = "train.min",
+  name = "Training min",
   fun = function(task, perf.test, perf.train, measure, group, pred) min(perf.train)
 )
 
@@ -119,6 +131,7 @@ train.min = makeAggregation(
 #' @rdname aggregations
 train.max = makeAggregation(
   id = "train.max",
+  name = "Training max",
   fun = function(task, perf.test, perf.train, measure, group, pred) max(perf.train)
 )
 
@@ -126,6 +139,7 @@ train.max = makeAggregation(
 #' @rdname aggregations
 train.sum = makeAggregation(
   id = "train.sum",
+  name = "Training sum",
   fun = function(task, perf.test, perf.train, measure, group, pred) sum(perf.train)
 )
 
@@ -133,6 +147,7 @@ train.sum = makeAggregation(
 #' @rdname aggregations
 train.range = makeAggregation(
   id = "train.range",
+  name = "Training range",
   fun = function(task, perf.test, perf.train, measure, group, pred) diff(range(perf.train))
 )
 
@@ -140,6 +155,7 @@ train.range = makeAggregation(
 #' @rdname aggregations
 train.sqrt.of.mean = makeAggregation(
   id = "train.sqrt.of.mean",
+  name = "Training RMSE",
   fun = function(task, perf.test, perf.train, measure, group, pred) sqrt(mean(perf.train))
 )
 
@@ -147,6 +163,7 @@ train.sqrt.of.mean = makeAggregation(
 #' @rdname aggregations
 b632 = makeAggregation(
   id = "b632",
+  name = ".632 Bootstrap",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     mean(0.632*perf.test + 0.368*perf.train)
   }
@@ -158,6 +175,7 @@ b632 = makeAggregation(
 #' @rdname aggregations
 b632plus = makeAggregation(
   id = "b632plus",
+  name = ".632 Bootstrap plus",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     df = as.data.frame(pred)
     a = numeric(length(perf.test))
@@ -182,6 +200,7 @@ b632plus = makeAggregation(
 #' @rdname aggregations
 testgroup.mean = makeAggregation(
   id = "testgroup.mean",
+  name = "Test group mean",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     mean(vnapply(split(perf.test, group), mean))
   }
@@ -191,6 +210,7 @@ testgroup.mean = makeAggregation(
 #' @rdname aggregations
 test.join = makeAggregation(
   id = "test.join",
+  name = "Test join",
   fun = function(task, perf.test, perf.train, measure, group, pred) {
     df = as.data.frame(pred)
     f = if (length(group)) group[df$iter] else factor(rep(1L, nrow(df)))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,8 +6,14 @@ cleanupPackageNames = function(pkgs) {
   gsub("^[!_]", "", pkgs)
 }
 
+# paste together measure and aggregation ids
 measureAggrName = function(measure) {
   paste(measure$id, measure$aggr$id, sep = ".")
+}
+
+# paste together measure and aggregation names
+measureAggrPrettyName = function(measure) {
+  paste(measure$name, measure$aggr$name, sep = ": ")
 }
 
 perfsToString = function(y) {
@@ -60,4 +66,20 @@ getSupportedLearnerProperties = function(type = NA_character_) {
     unique(unlist(p))
   else
     p[[type]]
+}
+
+# find duplicate measure names or ids and paste together those
+# with the associated aggregation ids or names
+replaceDupeMeasureNames = function(measures, x = "id") {
+  assertList(measures, "Measure")
+  assertChoice(x, c("id", "name"))
+  meas.names = extractSubList(measures, x)
+  dupes = table(meas.names)
+  dupes = which(meas.names %in% names(dupes[dupes > 1]))
+  if (x == "id")
+    new.names = sapply(measures[dupes], function(x) measureAggrName(x))
+  else
+    new.names = sapply(measures[dupes], function(x) measureAggrPrettyName(x))
+  meas.names[dupes] = new.names
+  unlist(meas.names)
 }

--- a/man/makeAggregation.Rd
+++ b/man/makeAggregation.Rd
@@ -4,11 +4,14 @@
 \alias{makeAggregation}
 \title{Specifiy your own aggregation of measures}
 \usage{
-makeAggregation(id, fun)
+makeAggregation(id, name, fun)
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr
 Name of the aggregation method. (Preferably the same name as the generated function)}
+
+\item{name}{[\code{character(1)}]\cr
+Long name of the aggregation method.}
 
 \item{fun}{[\code{function}]\cr
 A function with following signature: \code{function(task, perf.test, perf.train, measure, group, pred)}
@@ -30,7 +33,7 @@ inner workings so the result might not be compatible with everything! \cr
 }
 \examples{
 # computes the interquartile range on all performance values
-test.iqr = makeAggregation(id = "test.iqr",
+test.iqr = makeAggregation(id = "test.iqr", name = "Test set interquartile range",
   fun = function (task, perf.test, perf.train, measure, group, pred) IQR(perf.test))
 }
 \seealso{

--- a/man/makeCostMeasure.Rd
+++ b/man/makeCostMeasure.Rd
@@ -5,7 +5,7 @@
 \title{Creates a measure for non-standard misclassification costs.}
 \usage{
 makeCostMeasure(id = "costs", minimize = TRUE, costs, task,
-  combine = mean, best = NULL, worst = NULL)
+  combine = mean, best = NULL, worst = NULL, name = id, note = "")
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr
@@ -37,6 +37,12 @@ Default is -\code{Inf} or \code{Inf}, depending on \code{minimize}.}
 \item{worst}{[\code{numeric(1)}]\cr
 Worst obtainable value for measure.
 Default is \code{Inf} or -\code{Inf}, depending on \code{minimize}.}
+
+\item{name}{[\code{character}] \cr
+Name of the measure. Default is \code{id}.}
+
+\item{note}{[\code{character}] \cr
+Description and additional notes for the measure. Default is \dQuote{}.}
 }
 \value{
 [\code{\link{Measure}}].

--- a/man/makeCustomResampledMeasure.Rd
+++ b/man/makeCustomResampledMeasure.Rd
@@ -4,12 +4,17 @@
 \alias{makeCustomResampledMeasure}
 \title{Construct your own resampled performance measure.}
 \usage{
-makeCustomResampledMeasure(id, minimize = TRUE, properties = character(0L),
-  fun, extra.args = list(), best = NULL, worst = NULL)
+makeCustomResampledMeasure(measure.id, aggregation.id, minimize = TRUE,
+  properties = character(0L), fun, extra.args = list(), best = NULL,
+  worst = NULL, measure.name = measure.id,
+  aggregation.name = aggregation.id, note = "")
 }
 \arguments{
-\item{id}{[\code{character(1)}]\cr
-Name of aggregated measure.}
+\item{measure.id}{[\code{character(1)}]\cr
+Short name of measure.}
+
+\item{aggregation.id}{[\code{character(1)}]\cr
+Short name of aggregation.}
 
 \item{minimize}{[\code{logical(1)}]\cr
 Should the measure be minimized?
@@ -47,6 +52,17 @@ Default is -\code{Inf} or \code{Inf}, depending on \code{minimize}.}
 \item{worst}{[\code{numeric(1)}]\cr
 Worst obtainable value for measure.
 Default is \code{Inf} or -\code{Inf}, depending on \code{minimize}.}
+
+\item{measure.name}{[\code{character(1)}]\cr
+Long name of measure.
+Default is \code{measure.id}.}
+
+\item{aggregation.name}{[\code{character(1)}]\cr
+Long name of the aggregation.
+Default is \code{aggregation.id}.}
+
+\item{note}{[\code{character}] \cr
+Description and additional notes for the measure. Default is \dQuote{}.}
 }
 \value{
 [\code{\link{Measure}}].

--- a/man/makeMeasure.Rd
+++ b/man/makeMeasure.Rd
@@ -58,7 +58,7 @@ Default is \code{Inf} or -\code{Inf}, depending on \code{minimize}.}
 Name of the measure. Default is \code{id}.}
 
 \item{note}{[\code{character}] \cr
-Description and additional notes for the learner. Default is \dQuote{}.}
+Description and additional notes for the measure. Default is \dQuote{}.}
 }
 \value{
 [\code{\link{Measure}}].

--- a/man/plotLearningCurve.Rd
+++ b/man/plotLearningCurve.Rd
@@ -4,7 +4,7 @@
 \alias{plotLearningCurve}
 \title{Plot learning curve data using ggplot2.}
 \usage{
-plotLearningCurve(obj, facet = "measure")
+plotLearningCurve(obj, facet = "measure", pretty.names = TRUE)
 }
 \arguments{
 \item{obj}{[\code{LearningCurveData}]\cr
@@ -15,6 +15,10 @@ Selects \dQuote{measure} or \dQuote{learner} to be the facetting variable.
 The variable mapped to \code{facet} must have more than one unique value, otherwise it will
 be ignored. The variable not chosen is mapped to color if it has more than one unique value.
 The default is \dQuote{measure}.}
+
+\item{pretty.names}{[\code{logical(1)}]\cr
+Whether to use the \code{\link{Measure}} name instead of the id in the plot.
+Default is \code{TRUE}.}
 }
 \value{
 ggplot2 plot object.

--- a/man/plotLearningCurveGGVIS.Rd
+++ b/man/plotLearningCurveGGVIS.Rd
@@ -4,7 +4,7 @@
 \alias{plotLearningCurveGGVIS}
 \title{Plot learning curve data using ggvis.}
 \usage{
-plotLearningCurveGGVIS(obj, interaction = "measure")
+plotLearningCurveGGVIS(obj, interaction = "measure", pretty.names = TRUE)
 }
 \arguments{
 \item{obj}{[\code{LearningCurveData}]\cr
@@ -18,6 +18,10 @@ The variable not chosen is mapped to color if it has more than one unique value.
 Note that if there are multiple learners and multiple measures interactivity is
 necessary as ggvis does not currently support facetting or subplots.
 The default is \dQuote{measure}.}
+
+\item{pretty.names}{[\code{logical(1)}]\cr
+Whether to use the \code{\link{Measure}} name instead of the id in the plot.
+Default is \code{TRUE}.}
 }
 \value{
 a ggvis plot object.

--- a/man/plotThreshVsPerf.Rd
+++ b/man/plotThreshVsPerf.Rd
@@ -4,7 +4,8 @@
 \alias{plotThreshVsPerf}
 \title{Plot threshold vs. performance(s) for 2-class classification using ggplot2.}
 \usage{
-plotThreshVsPerf(obj, facet = "measure", mark.th = NA_real_)
+plotThreshVsPerf(obj, facet = "measure", mark.th = NA_real_,
+  pretty.names = TRUE)
 }
 \arguments{
 \item{obj}{[\code{ThreshVsPerfData}]\cr
@@ -19,6 +20,10 @@ The default is \dQuote{measure}.}
 \item{mark.th}{[\code{numeric(1)}]\cr
 Mark given threshold with vertical line?
 Default is \code{NA} which means not to do it.}
+
+\item{pretty.names}{[\code{logical(1)}]\cr
+Whether to use the \code{\link{Measure}} name instead of the id in the plot.
+Default is \code{TRUE}.}
 }
 \value{
 ggplot2 plot object.
@@ -30,7 +35,7 @@ Plot threshold vs. performance(s) for 2-class classification using ggplot2.
 lrn = makeLearner("classif.rpart", predict.type = "prob")
 mod = train(lrn, sonar.task)
 pred = predict(mod, sonar.task)
-pvs = generateThreshVsPerfData(pred, list(tpr, fpr))
+pvs = generateThreshVsPerfData(pred, list(acc, setAggregation(acc, train.mean)))
 plotThreshVsPerf(pvs)
 }
 \seealso{

--- a/man/plotThreshVsPerfGGVIS.Rd
+++ b/man/plotThreshVsPerfGGVIS.Rd
@@ -4,7 +4,8 @@
 \alias{plotThreshVsPerfGGVIS}
 \title{Plot threshold vs. performance(s) for 2-class classification using ggvis.}
 \usage{
-plotThreshVsPerfGGVIS(obj, interaction = "measure", mark.th = NA_real_)
+plotThreshVsPerfGGVIS(obj, interaction = "measure", mark.th = NA_real_,
+  pretty.names = TRUE)
 }
 \arguments{
 \item{obj}{[\code{ThreshVsPerfData}]\cr
@@ -22,6 +23,10 @@ The default is \dQuote{measure}.}
 \item{mark.th}{[\code{numeric(1)}]\cr
 Mark given threshold with vertical line?
 Default is \code{NA} which means not to do it.}
+
+\item{pretty.names}{[\code{logical(1)}]\cr
+Whether to use the \code{\link{Measure}} name instead of the id in the plot.
+Default is \code{TRUE}.}
 }
 \value{
 a ggvis plot object.

--- a/tests/testthat/test_base_generateLearningCurve.R
+++ b/tests/testthat/test_base_generateLearningCurve.R
@@ -4,7 +4,7 @@ test_that("generateLearningCurve", {
   r = generateLearningCurveData(list("classif.rpart", "classif.knn"),
                                 task = binaryclass.task, percs = c(0.1, 0.3),
                                 measures = list(acc, timeboth))
-  expect_true(all(c("learner", "perc", "acc", "timeboth") %in% colnames(r$data)))
+  expect_true(all(c("learner", "percentage", "acc", "timeboth") %in% colnames(r$data)))
   plotLearningCurve(r)
   ## plotLearningCurveGGVIS(r)
 
@@ -12,13 +12,14 @@ test_that("generateLearningCurve", {
                                 task = regr.num.task, percs = c(0.1, 0.2),
                                 resampling = makeResampleDesc(method = "CV", iters = 2),
                                 measures = list(sse, timeboth))
-  expect_true(all(c("learner", "perc", "sse", "timeboth") %in% colnames(r$data)))
+  expect_true(all(c("learner", "percentage", "sse", "timeboth") %in% colnames(r$data)))
   plotLearningCurve(r)
   ## plotLearningCurveGGVIS(r)
 
   r = generateLearningCurveData(list("classif.rpart", "classif.knn"),
                                 task = binaryclass.task, percs = c(0.1, 0.3),
-                                measures = acc)
+                                resampling = makeResampleDesc("Holdout", predict = "both"),
+                                measures = list(acc, setAggregation(acc, train.mean)))
   plotLearningCurve(r)
   plotLearningCurveGGVIS(r) ## not interactive by default
 })

--- a/tests/testthat/test_base_generateThreshVsPerf.R
+++ b/tests/testthat/test_base_generateThreshVsPerf.R
@@ -35,7 +35,8 @@ test_that("generateThreshVsPerfData", {
   classes = levels(getTaskTargets(binaryclass.task))
   mcm = matrix(sample(0:3, size = (length(classes))^2, TRUE), ncol = length(classes))
   rownames(mcm) = colnames(mcm) = classes
-  costs = makeCostMeasure(id = "costs", minimize = TRUE, costs = mcm, binaryclass.task, combine = mean)
+  costs = makeCostMeasure(id = "asym.costs", name = "Asymmetric costs",
+                          minimize = TRUE, costs = mcm, binaryclass.task, combine = mean)
   pvs.custom = generateThreshVsPerfData(pred, costs)
   plotThreshVsPerf(pvs.custom)
   ## plotThreshVsPerfGGVIS(pvs.custom)

--- a/tests/testthat/test_base_performance.R
+++ b/tests/testthat/test_base_performance.R
@@ -5,7 +5,7 @@ test_that("performance", {
   lrn = makeLearner("classif.rpart")
   rf = resample(lrn, task = binaryclass.task, resampling = res, measures = list(acc, timeboth))
 
-  res = makeResampleDesc("Bootstrap", iters = 3)
+  res = makeResampleDesc("Bootstrap", iters = 3L)
   rf = resample(lrn, task = binaryclass.task, resampling = res, measures = list(acc, timeboth))
   m = setAggregation(acc, test.median)
   rf = resample(lrn, task = binaryclass.task, resampling = res, measures = m)
@@ -35,14 +35,14 @@ test_that("performance", {
   expect_equal(names(res), c("ber", "acc", "tp"))
 
   # custom measure
-
-  mymeasure = makeCustomResampledMeasure(id = "mym", properties = c("classif", "predtype.response"),
+  mymeasure = makeCustomResampledMeasure(measure.id = "mym", aggregation.id = "train.mean",
+                                         properties = c("classif", "predtype.response"),
     fun = function(task, group, pred, feats, extra.args) {
       mean(pred$data$truth != pred$data$response)
     })
   rdesc = makeResampleDesc("Holdout")
   r = resample(lrn, binaryclass.task, rdesc, measures = list(mmce, mymeasure))
-  expect_equal(as.numeric(r$aggr["mmce.test.mean"]), as.numeric(r$aggr["custom.mym"]))
+  expect_equal(as.numeric(r$aggr["mmce.test.mean"]), as.numeric(r$aggr["mym.train.mean"]))
 })
 
 
@@ -54,4 +54,3 @@ test_that("performance checks for missing truth col", {
 
   expect_error(performance(pred, measure = mmce), "need to have a 'truth' col")
 })
-


### PR DESCRIPTION
 - aggregations now have long names
 - if measure ids/names match in generation functions, aggregation ids
   are appended to column names
 - plotThreshVsPerf/GGVIS and plotLearningCurve/GGVIS have argument
   'pretty.names' which optionally uses measure and aggregation names
   instead of ids for plotting (default is TRUE)
 - new helper functions measureAggrPrettyName and replaceDupeMeasureNames